### PR TITLE
added lora and ti support via prompt syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Update: I applied a fix to space out requests because horde now has a rate limit
 now supports SDXL officially, I also swapped out sdxl_beta model name for SDXL 1.0 and removed the inpainting 
 and image amount overrides from it.
 
+Jan. 8, 2024: Added LoRa/TI support. In your prompt, use the syntax `<lora:id:strength>` or `<ti:id>` to add them to your request. For LoRas, put a 'v' before the id to use the version id instead. Not that for both loras and tis, only integer ids are supported. (Added by rbrtcs1)
+
 # stable-ui 🔥
 
 [Stable UI](https://aqualxx.github.io/stable-ui/) is a web user interface designed to generate, save, and view images using Stable Diffusion, with the goal being able to provide Stable Diffusion to anyone for 100% free.

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -108,42 +108,42 @@ interface CarouselOutput {
 }
 
 function updateParametersWithLorasAndTis(parameters: { prompt: string, loras?: { name: string, model: number, is_version: boolean }[], tis?: { name: string }[] }) {
-  let prompt = parameters.prompt;
-  let LORA_PATTERN = /<lora:v?[0-9]+:-?[0-9.]+>/g;
-  let TI_PATTERN = /<ti:[0-9]+>/g;
-  let loraMatches = prompt.match(LORA_PATTERN) || [];
-  let loras = loraMatches.map((match) => {
-    let data = match.substring(6); // Removes "<lora:"
-    data = data.slice(0, -1); // removes trailing '>'
-    let comps = data.split(":");
-    // ["12345", "1.0"]
-    let loraID = comps[0];
-    let isVersion = false;
-    if (loraID.startsWith("v")) {
-      loraID = loraID.substring(1);
-      isVersion = true;
-    }
-    let loraStr = parseFloat(comps[1].trim());
-    return {
-      name: loraID.trim(),
-      model: loraStr,
-      is_version: isVersion,
-    };
-  });
-  let tiMatches = prompt.match(TI_PATTERN) || [];
-  let tis = tiMatches.map((match) => {
-    let tiID = match.substring(4); // Removes "<ti:"
-    tiID = tiID.slice(0, -1); // removes trailing '>'
-    return {
-      name: tiID.trim(),
-    };
-  });
-  parameters.loras = loras;
-  parameters.tis = tis;
-  // Remove the codes from the prompt
-  prompt = prompt.replace(LORA_PATTERN, "");
-  prompt = prompt.replace(TI_PATTERN, "");
-  parameters.prompt = prompt;
+    let prompt = parameters.prompt;
+    const LORA_PATTERN = /<lora:v?[0-9]+:-?[0-9.]+>/g;
+    const TI_PATTERN = /<ti:[0-9]+>/g;
+    let loraMatches = prompt.match(LORA_PATTERN) || [];
+    let loras = loraMatches.map((match) => {
+        let data = match.substring(6); // Removes "<lora:"
+        data = data.slice(0, -1); // removes trailing '>'
+        let comps = data.split(":");
+        // ["12345", "1.0"]
+        let loraID = comps[0];
+        let isVersion = false;
+        if (loraID.startsWith("v")) {
+            loraID = loraID.substring(1);
+            isVersion = true;
+        }
+        let loraStr = parseFloat(comps[1].trim());
+        return {
+            name: loraID.trim(),
+            model: loraStr,
+            is_version: isVersion,
+        };
+    });
+    let tiMatches = prompt.match(TI_PATTERN) || [];
+    let tis = tiMatches.map((match) => {
+        let tiID = match.substring(4); // Removes "<ti:"
+        tiID = tiID.slice(0, -1); // removes trailing '>'
+        return {
+            name: tiID.trim(),
+        };
+    });
+    parameters.loras = loras;
+    parameters.tis = tis;
+    // Remove the codes from the prompt
+    prompt = prompt.replace(LORA_PATTERN, "");
+    prompt = prompt.replace(TI_PATTERN, "");
+    parameters.prompt = prompt;
 };
 
 export const useGeneratorStore = defineStore("generator", () => {

--- a/src/types/stable_horde.d.ts
+++ b/src/types/stable_horde.d.ts
@@ -141,6 +141,9 @@ export interface ModelPayloadRootStable {
    * @example 0.75
    */
   facefixer_strength?: number;
+
+  loras?: any[],
+  tis?: any[],
 }
 
 export interface RequestError {


### PR DESCRIPTION
Added support for loras and tis in a relatively simple way by (just before the horde generate api call):
- Using regex to extract the LoRas and TIs from the prompt
- Add them into the parameters object just before it's converted into the horde payload.

To be honest, this isn't a great solution, but it should work.